### PR TITLE
ProfileEditIssue

### DIFF
--- a/Views/ViewProfilePage.xaml.cs
+++ b/Views/ViewProfilePage.xaml.cs
@@ -21,7 +21,7 @@ namespace Telerik.Windows.Controls.Cloud.Sample.Views
             if (e.NavigationMode == System.Windows.Navigation.NavigationMode.New)
             {
                 var user = (CustomUser)this.NavigationContext.GetData();
-                if (user != null)
+                if (user != null && user.Id != CloudProvider.Current.CurrentUser.GetId())
                 {
                     this.DataContext = user;
                     this.currentUser = user;


### PR DESCRIPTION
This is for Issue #1 that I had raised

When the profile page is of the current user, even when coming from the
Friends list, the DataContext should be set from CloudProvider, so any
updates would be shown realtime.

This is the same that happens when coming directly to profile from
Welcome screen.